### PR TITLE
Jogadores 3 e 4 adicionados

### DIFF
--- a/scenes/jogo.tscn
+++ b/scenes/jogo.tscn
@@ -14,6 +14,10 @@ script = ExtResource("1_1b3iq")
 
 [node name="Jogador2" parent="." instance=ExtResource("3_k05ng")]
 
+[node name="Jogador3" parent="." instance=ExtResource("3_k05ng")]
+
+[node name="Jogador4" parent="." instance=ExtResource("3_k05ng")]
+
 [node name="Tabuleiro" parent="." instance=ExtResource("2_k05ng")]
 
 [node name="JogadorHud" parent="." instance=ExtResource("4_k05ng")]

--- a/scripts/jogo.gd
+++ b/scripts/jogo.gd
@@ -31,9 +31,15 @@ func iniciar_jogo() -> void:
 		if child is Jogador:
 			jogadores.append(child)
 	
-	if jogadores.size() >= 2:
-		jogadores[0].set_cor(Color.BLUE)
-		jogadores[1].set_cor(Color.DARK_RED)
+	var cores = [
+		Color.BLUE,
+		Color.DARK_RED,
+		Color.DARK_GREEN,
+		Color.DARK_GOLDENROD
+	]
+	
+	for i in range(min(jogadores.size(), cores.size())):
+		jogadores[i].set_cor(cores[i])
 	
 	if jogadores.is_empty() or tabuleiro == null:
 		print("ERRO: Jogadores ou tabuleiro não configurados na cena Jogo.")


### PR DESCRIPTION
Na verdade foi uma alteração bem simples, eu mudei o esquema de cores pra permitir que eventualmente nos pudéssemos atribuir elas a outros peões de maneira mais simples. Além disso, obviamente eu já fui em frente e coloquei os nodes do 3 e 4 jogadores na cena do jogo.